### PR TITLE
Fix travis-ubuntu:20.04 pipeline build

### DIFF
--- a/travis-ubuntu/20.04/Dockerfile
+++ b/travis-ubuntu/20.04/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get install -y \
     ragel \
     gengetopt \
     doxygen \
+    pulseaudio \
     graphviz \
     libuv1-dev \
     libunwind-dev \


### PR DESCRIPTION
Hello @gavv as we talked:

   - I verified and pulse audio was not installed in travis-ubuntu:20.04
   - I have modified the dockerfile in local to install it.
   - I tested in my local machine and all the builds and tests seems to be working, so i'm doing this pull request 
