### PR TITLE
Java android emulator

### DIFF
--- a/java-android/Dockerfile
+++ b/java-android/Dockerfile
@@ -8,6 +8,8 @@ ARG CMAKE_VERSION="3.10.2.4988404"
 
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN dpkg --add-architecture i386
+
 RUN apt-get update
 
 # native compilers
@@ -34,8 +36,22 @@ RUN apt-get install -y \
     make \
     cmake
 
+# emulator dependencies
+RUN apt-get install -y --no-install-recommends \
+    libncurses5:i386 \
+    libc6:i386 \
+    libstdc++6:i386 \
+    lib32gcc1 \
+    lib32ncurses6 \
+    lib32z1 \
+    zlib1g:i386 \
+    qt5-default
+
 ENV ANDROID_SDK_ROOT=$HOME/sdk
 ENV PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/tools/bin
+ENV PATH=$PATH:$ANDROID_SDK_ROOT/platform-tools
+ENV PATH=$PATH:$ANDROID_SDK_ROOT/emulator
+ENV LD_LIBRARY_PATH=$ANDROID_SDK_ROOT/emulator/lib64:$ANDROID_SDK_ROOT/emulator/lib64/qt/lib
 
 # default env settings
 ENV API=$API
@@ -72,9 +88,14 @@ RUN mv -f $ANDROID_SDK_ROOT/cmdline-tools/tools/bin/sdkmanager.tmp $ANDROID_SDK_
 RUN mkdir -p $HOME/.android && touch $HOME/.android/repositories.cfg
 
 RUN yes | sdkmanager --licenses
+RUN yes | sdkmanager "emulator"
 
 VOLUME [ "${ANDROID_SDK_ROOT}" ]
 
 COPY entrypoint.sh /opt/entrypoint.sh
+COPY device.sh /usr/bin/device
+
+# expose adb server port
+EXPOSE 5037
 
 ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/java-android/device.sh
+++ b/java-android/device.sh
@@ -55,7 +55,12 @@ function start_device() {
     fi
     adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill &> /dev/null; done
     echo "starting device \"${name}\""
-    emulator -avd "${name}" -no-audio -no-boot-anim -no-window -accel on -gpu off &> /dev/null &
+    flags="-no-audio -no-boot-anim -no-window -gpu off"
+    # check if hardware acceleration is available
+    (emulator -accel-check | grep -q 'is installed and usable') && \
+        flags="${flags} -accel on" || \
+        flags="${flags} -accel off"
+    emulator -avd "${name}" $flags &> /dev/null &
     boot_completed="0"
     while [ "$boot_completed" != "1" ]; do
         boot_completed=$(adb wait-for-device shell getprop sys.boot_completed | tr -d '\r')

--- a/java-android/device.sh
+++ b/java-android/device.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+me=$(basename "$0")
+
+api="${API}"
+arch="x86_64"
+
+function usage() {
+    cat << EOF
+Usage: $me [OPTIONS] ACTION
+
+Options:
+    --api=API        android API for emulator
+    --arch=ARCH      android ARCH for emulator
+    --image=IMAGE    android system image for emulator
+    --name=NAME      android device name
+    --help           show this help and exit
+
+Actions:
+    create           create a new android device
+    start            boot on android device
+EOF
+}
+
+function arg_error() {
+    echo "$me: unrecognized option '$1'"
+    echo "Try '$me --help' for more information."
+}
+
+function create_device() {
+    if [ "${image-}" = "" ]; then
+        echo "no 'image' specified" >&2
+        echo "Try '$me --help' for more information." >&2
+        exit 1
+    fi
+    if [ "${name-}" = "" ]; then
+        echo "no 'name' specified" >&2
+        echo "Try '$me --help' for more information." >&2
+        exit 1
+    fi
+    package="system-images;android-${api};${image};${arch}"
+    if [ ! -d ${ANDROID_SDK_ROOT}/system-images/android-${api}/${image}/${arch} ]; then
+        echo "--- installing system image android-${api};${image};${arch}"
+        ( yes | sdkmanager $package > /dev/null ) || exit 1
+    fi
+    echo "creating device \"${name}\""
+    echo no | avdmanager create avd --name "${name}" --package $package > /dev/null
+}
+
+function start_device() {
+    if [ "${name-}" = "" ]; then
+        echo "no 'name' specified" >&2
+        echo "Try '$me --help' for more information." >&2
+        exit 1
+    fi
+    adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill &> /dev/null; done
+    echo "starting device \"${name}\""
+    emulator -avd "${name}" -no-audio -no-boot-anim -no-window -accel on -gpu off &> /dev/null &
+    boot_completed="0"
+    while [ "$boot_completed" != "1" ]; do
+        boot_completed=$(adb wait-for-device shell getprop sys.boot_completed | tr -d '\r')
+        sleep 1
+    done
+    echo "device \"${name}\" started"
+}
+
+# read arguments
+opts=$(getopt \
+    --longoptions "api:,arch:,image:,name:,help" \
+    --name "$me" \
+    --options "" \
+    -- "$@"
+)
+
+eval set --$opts
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --api)
+            api=$2
+            shift 2
+            ;;
+        --arch)
+            arch=$2
+            shift 2
+            ;;
+        --image)
+            image=$2
+            shift 2
+            ;;
+        --name)
+            name=$2
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        --) shift ; break ;;
+        *)
+            arg_error "$1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift $(($OPTIND - 1))
+action=$1
+
+case "$action" in
+    create)
+        create_device
+        ;;
+    start)
+        start_device
+        ;;
+    *)
+        echo "unrecognized action ${action}" >&2
+        usage
+        exit 1
+        ;;
+esac

--- a/java-android/entrypoint.sh
+++ b/java-android/entrypoint.sh
@@ -2,23 +2,26 @@
 
 if [ ! -d ${ANDROID_SDK_ROOT}/platforms/android-${API} ]; then
     echo "--- installing android-${API} platform"
-    yes | sdkmanager "platforms;android-${API}" &> /dev/null
+    yes | sdkmanager "platforms;android-${API}" > /dev/null
 fi
 if [ ! -d ${ANDROID_SDK_ROOT}/build-tools/${BUILD_TOOLS_VERSION} ]; then
     echo "--- installing build-tools ${BUILD_TOOLS_VERSION}"
-    yes | sdkmanager "build-tools;${BUILD_TOOLS_VERSION}" &> /dev/null
+    yes | sdkmanager "build-tools;${BUILD_TOOLS_VERSION}" > /dev/null
 fi
 if [ ! -d ${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION} ]; then
     echo "--- installing ndk ${NDK_VERSION}"
-    yes | sdkmanager "ndk;${NDK_VERSION}" &> /dev/null
+    yes | sdkmanager "ndk;${NDK_VERSION}" > /dev/null
 fi
 if [ ! -d ${ANDROID_SDK_ROOT}/cmake/${CMAKE_VERSION} ]; then
     echo "--- installing cmake ${CMAKE_VERSION}"
-    yes | sdkmanager "cmake;${CMAKE_VERSION}" &> /dev/null
+    yes | sdkmanager "cmake;${CMAKE_VERSION}" > /dev/null
 fi
 
 export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}
 export PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/linux-x86_64/bin:${PATH}"
+
+# start adb server
+adb -a server nodaemon &> /dev/null &
 
 # exec user cmd
 exec "$@"


### PR DESCRIPTION
This PR adds android emulator to `java-android` image for instrumented tests, plus an helper script (`device` script) for creating and starting AVDs