### PR TITLE
Added Ubuntu 24.04 image to ci.

### DIFF
--- a/images/env-ubuntu/24.04/Dockerfile
+++ b/images/env-ubuntu/24.04/Dockerfile
@@ -10,11 +10,16 @@ RUN apt-get install -y \
     clang \
     clang-13 \
     clang-14 \
+    clang-15 \
+    clang-16 \
+    clang-17 \
     clang-format \
     g++ \
+    g++-9 \
     g++-10 \
     g++-11 \
     g++-12 \
+    g++-13 \
     git \
     python3 \
     valgrind

--- a/images/env-ubuntu/24.04/Dockerfile
+++ b/images/env-ubuntu/24.04/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+
+# compilers and tools
+RUN apt-get install -y \
+    ccache \
+    clang \
+    clang-13 \
+    clang-14 \
+    clang-format \
+    g++ \
+    g++-10 \
+    g++-11 \
+    g++-12 \
+    git \
+    python3 \
+    valgrind
+
+# for 3rd-parties
+RUN apt-get install -y \
+    autoconf \
+    automake \
+    cmake \
+    intltool \
+    libtool \
+    m4 \
+    make \
+    meson \
+    pkg-config
+
+# for roc
+RUN apt-get install -y \
+    doxygen \
+    gengetopt \
+    graphviz \
+    libasound2-dev \
+    libbenchmark-dev \
+    libcpputest-dev \
+    libpulse-dev \
+    libsndfile-dev \
+    libsox-dev \
+    libspeexdsp-dev \
+    libssl-dev \
+    libunwind-dev \
+    libuv1-dev \
+    pulseaudio \
+    ragel \
+    scons

--- a/images/env-ubuntu/images.csv
+++ b/images/env-ubuntu/images.csv
@@ -5,4 +5,5 @@ DOCKERFILE;ARGS (comma-separated list);TAG
 20.04/Dockerfile;;
 22.04/Dockerfile;;
 22.04/Dockerfile;;latest
+24.04/Dockerfile;;
 nolibs/Dockerfile;;


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/634

This adds the Ubuntu 24.04 image

# What

* Created a new env-ubuntu dir with a Dockerfile for 24.04, copied from 22.04.
  * Removed clang-11 and clang-12, which are not available.
  * Added more clang and g++ versions, so that we have a complete set - not necessarily all have to be used for builds.
* Updated csv file.

# Testing

Ran make.sh script to build image locally.
