### PR TITLE
Add sndfile to images that support it

### DIFF
--- a/images/env-alpine/Dockerfile
+++ b/images/env-alpine/Dockerfile
@@ -28,6 +28,7 @@ RUN apk add \
     doxygen \
     gengetopt \
     graphviz \
+    libsndfile \
     libunwind-dev \
     libuv-dev \
     openssl-dev \

--- a/images/env-alpine/Dockerfile
+++ b/images/env-alpine/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add \
     doxygen \
     gengetopt \
     graphviz \
-    libsndfile \
+    libsndfile-dev \
     libunwind-dev \
     libuv-dev \
     openssl-dev \

--- a/images/env-archlinux/Dockerfile
+++ b/images/env-archlinux/Dockerfile
@@ -31,6 +31,7 @@ RUN pacman --noconfirm -S \
     graphviz \
     gsm \
     libpulse \
+    libsndfile \
     libunwind \
     libuv \
     openssl \

--- a/images/env-debian/Dockerfile
+++ b/images/env-debian/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get install -y \
     libasound2-dev \
     libbenchmark-dev \
     libpulse-dev \
+    libsndfile1-dev \
     libsox-dev \
     libspeexdsp-dev \
     libssl-dev \

--- a/images/env-fedora/Dockerfile
+++ b/images/env-fedora/Dockerfile
@@ -25,6 +25,7 @@ RUN dnf install -y \
     gengetopt \
     google-benchmark-devel \
     graphviz \
+    libsndfile \
     libunwind-devel \
     libuv-devel \
     openssl-devel \

--- a/images/env-fedora/Dockerfile
+++ b/images/env-fedora/Dockerfile
@@ -25,7 +25,7 @@ RUN dnf install -y \
     gengetopt \
     google-benchmark-devel \
     graphviz \
-    libsndfile \
+    libsndfile-devel \
     libunwind-devel \
     libuv-devel \
     openssl-devel \

--- a/images/env-opensuse/Dockerfile
+++ b/images/env-opensuse/Dockerfile
@@ -27,7 +27,7 @@ RUN zypper -n install \
     graphviz \
     libopenssl-3-devel \
     libpulse-devel \
-    libsndfile1-dev \
+    libsndfile-devel \
     libunwind-devel \
     libuv-devel \
     ragel \

--- a/images/env-opensuse/Dockerfile
+++ b/images/env-opensuse/Dockerfile
@@ -27,6 +27,7 @@ RUN zypper -n install \
     graphviz \
     libopenssl-3-devel \
     libpulse-devel \
+    libsndfile \
     libunwind-devel \
     libuv-devel \
     ragel \

--- a/images/env-opensuse/Dockerfile
+++ b/images/env-opensuse/Dockerfile
@@ -27,7 +27,7 @@ RUN zypper -n install \
     graphviz \
     libopenssl-3-devel \
     libpulse-devel \
-    libsndfile \
+    libsndfile1-dev \
     libunwind-devel \
     libuv-devel \
     ragel \

--- a/images/env-ubuntu/14.04/Dockerfile
+++ b/images/env-ubuntu/14.04/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get install -y \
     gengetopt \
     graphviz \
     libasound2-dev \
+    libsndfile-dev \
     libsox-dev \
     libspeexdsp-dev \
     libunwind8-dev \

--- a/images/env-ubuntu/16.04/Dockerfile
+++ b/images/env-ubuntu/16.04/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get install -y \
     libasound2-dev \
     libcpputest-dev \
     libpulse-dev \
+    libsndfile-dev \
     libsox-dev \
     libspeexdsp-dev \
     libunwind-dev \

--- a/images/env-ubuntu/18.04/Dockerfile
+++ b/images/env-ubuntu/18.04/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get install -y \
     libasound2-dev \
     libcpputest-dev \
     libpulse-dev \
+    libsndfile-dev \
     libsox-dev \
     libspeexdsp-dev \
     libssl-dev \

--- a/images/env-ubuntu/20.04/Dockerfile
+++ b/images/env-ubuntu/20.04/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get install -y \
     libbenchmark-dev \
     libcpputest-dev \
     libpulse-dev \
+    libsndfile-dev \
     libsox-dev \
     libspeexdsp-dev \
     libssl-dev \

--- a/images/env-ubuntu/24.04/Dockerfile
+++ b/images/env-ubuntu/24.04/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update
 RUN apt-get install -y \
     ccache \
     clang \
-    clang-13 \
     clang-14 \
     clang-15 \
     clang-16 \


### PR DESCRIPTION
**Why:**
https://github.com/roc-streaming/roc-toolkit/pull/660/files#diff-9ee9b1592092e1b7e9721e0fa24fb956e6f9fbad84abf76df25bbf1f93181f22. 

**What:**
I've added sndfile to the install commands of each image that I could find supported it. I looked through their respective package managers and opted for a developer version of sndfile when possible. I could not find a simple install command for Android from a package manager.

I did find this for android https://github.com/libsndfile/libsndfile/blob/master/Building-for-Android.md but am unsure if its relevant, as I am rather new to building Docker Images, and have no experience with Android environments. I'm looking to get advice on this one.