### PR TITLE
Add Ubuntu 26.04 folder and remove automake1.11 from all Dockerfiles

### DIFF
--- a/images/env-android/Dockerfile
+++ b/images/env-android/Dockerfile
@@ -1,4 +1,4 @@
-ARG OPENJDK="openjdk:17-jdk-slim-buster"
+ARG OPENJDK="eclipse-temurin:17-jdk-jammy"
 FROM $OPENJDK
 
 ARG API_LEVEL="29"
@@ -25,7 +25,6 @@ RUN apt-get install -y \
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     cmake \
     intltool \
     libtool \

--- a/images/env-android/images.csv
+++ b/images/env-android/images.csv
@@ -1,4 +1,4 @@
 DOCKERFILE;ARGS (comma-separated list);TAG
-;OPENJDK=openjdk:17-jdk-slim-buster;jdk17
-;OPENJDK=openjdk:21-jdk-slim-buster;jdk21
-;OPENJDK=openjdk:21-jdk-slim-buster;latest
+;OPENJDK=eclipse-temurin:17-jdk-jammy;jdk17
+;OPENJDK=eclipse-temurin:21-jdk-jammy;jdk21
+;OPENJDK=eclipse-temurin:21-jdk-jammy;latest

--- a/images/env-ubuntu/26.04/Dockerfile
+++ b/images/env-ubuntu/26.04/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+
+# compilers and tools
+RUN apt-get install -y \
+    ccache \
+    clang \
+    clang-17 \
+    clang-18 \
+    clang-19 \
+    clang-20 \
+    clang-21 \
+    clang-format \
+    g++ \
+    g++-11 \
+    g++-12 \
+    g++-13 \
+    g++-14 \
+    g++-15 \
+    git \
+    python3 \
+    valgrind
+
+# for 3rd-parties
+RUN apt-get install -y \
+    autoconf \
+    automake \
+    cmake \
+    intltool \
+    libtool \
+    m4 \
+    make \
+    meson \
+    pkg-config \
+    uuid-dev
+
+# for roc
+RUN apt-get install -y \
+    doxygen \
+    gengetopt \
+    graphviz \
+    libasound2-dev \
+    libbenchmark-dev \
+    libcpputest-dev \
+    libpulse-dev \
+    libsndfile-dev \
+    libsox-dev \
+    libspeexdsp-dev \
+    libssl-dev \
+    libunwind-dev \
+    libuv1-dev \
+    pulseaudio \
+    ragel \
+    scons

--- a/images/toolchain-aarch64-linux-gnu/Dockerfile
+++ b/images/toolchain-aarch64-linux-gnu/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-aarch64-linux-gnu/legacy/arm.com/Dockerfile
+++ b/images/toolchain-aarch64-linux-gnu/legacy/arm.com/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-aarch64-linux-gnu/legacy/linaro.org/Dockerfile
+++ b/images/toolchain-aarch64-linux-gnu/legacy/linaro.org/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-arm-bcm2708-linux-gnueabihf/Dockerfile
+++ b/images/toolchain-arm-bcm2708-linux-gnueabihf/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-arm-linux-gnueabihf/Dockerfile
+++ b/images/toolchain-arm-linux-gnueabihf/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-arm-linux-gnueabihf/legacy/arm.com/Dockerfile
+++ b/images/toolchain-arm-linux-gnueabihf/legacy/arm.com/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-arm-linux-gnueabihf/legacy/linaro.org/Dockerfile
+++ b/images/toolchain-arm-linux-gnueabihf/legacy/linaro.org/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-linux-android/Dockerfile
+++ b/images/toolchain-linux-android/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get install -y \
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     cmake \
     intltool \
     libtool \

--- a/images/toolchain-mips-openwrt-linux-atheros/12.09/Dockerfile
+++ b/images/toolchain-mips-openwrt-linux-atheros/12.09/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-mips-openwrt-linux-atheros/17.01/Dockerfile
+++ b/images/toolchain-mips-openwrt-linux-atheros/17.01/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \

--- a/images/toolchain-mips-openwrt-linux-atheros/24.10/Dockerfile
+++ b/images/toolchain-mips-openwrt-linux-atheros/24.10/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update
 RUN apt-get install -y \
     autoconf \
     automake \
-    automake1.11 \
     ccache \
     cmake \
     g++ \


### PR DESCRIPTION
The automake1.11 package was removed from Debian after Jessie