### PR TITLE
Comment out env-flutter:android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
           - env-debian
           - env-docs
           - env-fedora
-          - env-flutter:android
           - env-flutter:linux
           - env-opensuse
           - env-ubuntu:14.04

--- a/images/env-flutter/images.csv
+++ b/images/env-flutter/images.csv
@@ -1,4 +1,3 @@
 DOCKERFILE;ARGS (comma-separated list);TAG;OS
-Dockerfile.android;;android;linux
 Dockerfile.linux;;linux;linux
 Dockerfile.windows;;windows;windows


### PR DESCRIPTION
It needs too much of disk space to be built,
and it has found no use so far